### PR TITLE
Add comprehensive tests for admin API routes

### DIFF
--- a/app/Http/Controllers/Admin/TagController.php
+++ b/app/Http/Controllers/Admin/TagController.php
@@ -35,7 +35,10 @@ class TagController extends Controller
             'name' => 'required|string|max:255|unique:tags,name',
         ]);
 
-        $tag = Tag::create($data);
+        $tag = Tag::create([
+            'name' => $data['name'],
+            'platform_id' => current_platform_id() ?? auth()->user()?->current_platform_id,
+        ]);
 
         return response()->json($tag, 201);
     }
@@ -57,7 +60,9 @@ class TagController extends Controller
             'name' => 'required|string|max:255|unique:tags,name,' . $tag->id,
         ]);
 
-        $tag->update($data);
+        $tag->update([
+            'name' => $data['name'],
+        ]);
 
         return response()->json($tag);
     }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -10,7 +10,7 @@ class Tag extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name'];
+    protected $fillable = ['name', 'platform_id'];
 
     /**
      * Get the tag-course relationships for this tag.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -29,6 +29,7 @@ class User extends Authenticatable implements JWTSubject
         'email',
         'password',
         'role',
+        'current_platform_id',
     ];
 
     /**

--- a/database/factories/TagCourseFactory.php
+++ b/database/factories/TagCourseFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Course;
+use App\Models\Tag;
+use App\Models\TagCourse;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TagCourse>
+ */
+class TagCourseFactory extends Factory
+{
+    protected $model = TagCourse::class;
+
+    public function definition(): array
+    {
+        return [
+            'tag_id' => Tag::factory(),
+            'course_id' => Course::factory(),
+        ];
+    }
+}

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Platform;
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Tag>
+ */
+class TagFactory extends Factory
+{
+    protected $model = Tag::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->words(asText: true),
+            'platform_id' => Platform::factory(),
+        ];
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,8 @@
         <env name="ENV_FILE" value=".env.test" />
         <env name="BCRYPT_ROUNDS" value="4" />
         <env name="CACHE_DRIVER" value="array" />
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array" />
         <env name="PULSE_ENABLED" value="false" />
         <env name="QUEUE_CONNECTION" value="sync" />

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,13 +29,12 @@ Route::prefix('admin')->group(function () {
         Route::resource('teachers', App\Http\Controllers\Admin\TeachersController::class, ['except' => ['create', 'edit']]);
         Route::post('courses/{course}/update', [CoursesController::class, 'update'])->name('admin.courses.update');
         Route::post('courses/{course}/disable', [CoursesController::class, 'disable'])->name('admin.courses.disable');
-        Route::resource(name: '/courses/{course}/modules', controller: ModulesController::class);
-        Route::resource(name: '/courses/{course}/modules/{module}/videos', controller: VideosController::class);
-        Route::resource('users', UsersController::class);
+        Route::resource(name: '/courses/{course}/modules', controller: ModulesController::class, options: ['only' => ['index', 'store', 'update', 'destroy']]);
+        Route::resource(name: '/courses/{course}/modules/{module}/videos', controller: VideosController::class, options: ['only' => ['store', 'update', 'destroy']]);
+        Route::resource('users', UsersController::class, ['except' => ['create', 'edit']]);
 
         // Tags routes
-        Route::resource('tags', TagController::class);
-        Route::get('tags/{tag}/courses', [TagController::class, 'courses'])->name('admin.tags.courses');
+        Route::resource('tags', TagController::class, ['except' => ['create', 'edit']]);
 
         // Tag-Course relationship routes
         Route::resource('tag-courses', TagCourseController::class, ['except' => ['create', 'edit', 'update']]);

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -2,6 +2,8 @@
 
 namespace Tests;
 
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\Type;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Application;
 
@@ -15,6 +17,22 @@ trait CreatesApplication
         $app = require __DIR__ . '/../bootstrap/app.php';
         $app->loadEnvironmentFrom('.env.test');
         $app->make(Kernel::class)->bootstrap();
+
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => true,
+        ]);
+
+        if (class_exists(Type::class)) {
+            if (!Type::hasType('enum')) {
+                Type::addType('enum', StringType::class);
+            }
+
+            $app['db']->connection()->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+        }
 
         return $app;
     }

--- a/tests/Feature/Admin/AuthTest.php
+++ b/tests/Feature/Admin/AuthTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Admin;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -40,5 +40,19 @@ class AuthTest extends TestCase
         ]);
 
         $response->assertStatus(401);
+    }
+
+    public function test_refresh_returns_token_payload(): void
+    {
+        $response = $this->postJson('/api/admin/refresh');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'access_token',
+                'token_type',
+                'expires_in',
+                'user',
+                'platform_id',
+            ]);
     }
 }

--- a/tests/Feature/Admin/Courses/DisableCourseTest.php
+++ b/tests/Feature/Admin/Courses/DisableCourseTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature\Admin\Courses;
+
+use App\Models\Course;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DisableCourseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_disable_course_sets_status_to_draft(): void
+    {
+        $course = Course::factory()->create([
+            'status' => Course::STATUS_COMPLETE,
+        ]);
+
+        $response = $this->postJson(route('admin.courses.disable', $course));
+
+        $response->assertNoContent();
+        $this->assertEquals(Course::STATUS_DRAFT, $course->refresh()->status);
+    }
+}

--- a/tests/Feature/Admin/Courses/UpdateCourseTest.php
+++ b/tests/Feature/Admin/Courses/UpdateCourseTest.php
@@ -33,7 +33,7 @@ class UpdateCourseTest extends TestCase
         ];
 
         $response = $this->post(
-            uri: route('courses.update', $course),
+            uri: route('admin.courses.update', $course),
             data: $data,
             headers: [ 'Content-Type' => 'multipart/form-data' ]
         );
@@ -66,7 +66,7 @@ class UpdateCourseTest extends TestCase
             'status' => '',
         ];
 
-        $response = $this->post(route('courses.update', $course), $data, [
+        $response = $this->post(route('admin.courses.update', $course), $data, [
             'Content-Type' => 'multipart/form-data',
         ]);
 

--- a/tests/Feature/Admin/ModulesControllerTest.php
+++ b/tests/Feature/Admin/ModulesControllerTest.php
@@ -20,6 +20,17 @@ class ModulesControllerTest extends TestCase
         $this->faker = Faker::create();
     }
 
+    public function test_index_modules(): void
+    {
+        $course = Course::factory()->create();
+        Module::factory()->count(3)->create(['course_id' => $course->id]);
+
+        $response = $this->getJson($this->url($course));
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3);
+    }
+
     public function test_store_module()
     {
         $course = Course::factory()->create();

--- a/tests/Feature/Admin/TagControllerTest.php
+++ b/tests/Feature/Admin/TagControllerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TagControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_lists_tags(): void
+    {
+        Tag::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/admin/tags');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3);
+    }
+
+    public function test_store_creates_tag(): void
+    {
+        $response = $this->postJson('/api/admin/tags', [
+            'name' => 'Leadership',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('tags', ['name' => 'Leadership']);
+    }
+
+    public function test_show_returns_tag(): void
+    {
+        $tag = Tag::factory()->create();
+
+        $response = $this->getJson("/api/admin/tags/{$tag->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['id' => $tag->id]);
+    }
+
+    public function test_update_modifies_tag(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Old Name']);
+
+        $response = $this->putJson("/api/admin/tags/{$tag->id}", [
+            'name' => 'New Name',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('tags', [
+            'id' => $tag->id,
+            'name' => 'New Name',
+        ]);
+    }
+
+    public function test_destroy_deletes_tag_without_relations(): void
+    {
+        $tag = Tag::factory()->create();
+
+        $response = $this->deleteJson("/api/admin/tags/{$tag->id}");
+
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('tags', ['id' => $tag->id]);
+    }
+}

--- a/tests/Feature/Admin/TagCourseControllerTest.php
+++ b/tests/Feature/Admin/TagCourseControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Course;
+use App\Models\Tag;
+use App\Models\TagCourse;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TagCourseControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_lists_tag_courses(): void
+    {
+        TagCourse::factory()->count(2)->create();
+
+        $response = $this->getJson('/api/admin/tag-courses');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(2);
+    }
+
+    public function test_store_creates_tag_course(): void
+    {
+        $tag = Tag::factory()->create();
+        $course = Course::factory()->create();
+
+        $response = $this->postJson('/api/admin/tag-courses', [
+            'tag_id' => $tag->id,
+            'course_id' => $course->id,
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('tag_courses', [
+            'tag_id' => $tag->id,
+            'course_id' => $course->id,
+        ]);
+    }
+
+    public function test_show_returns_tag_course(): void
+    {
+        $tagCourse = TagCourse::factory()->create();
+
+        $response = $this->getJson("/api/admin/tag-courses/{$tagCourse->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['id' => $tagCourse->id]);
+    }
+
+    public function test_destroy_deletes_tag_course(): void
+    {
+        $tagCourse = TagCourse::factory()->create();
+
+        $response = $this->deleteJson("/api/admin/tag-courses/{$tagCourse->id}");
+
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('tag_courses', ['id' => $tagCourse->id]);
+    }
+
+    public function test_destroy_by_tag_and_course_route(): void
+    {
+        $tagCourse = TagCourse::factory()->create();
+
+        $response = $this->deleteJson(
+            "/api/admin/tag-courses/tag/{$tagCourse->tag_id}/course/{$tagCourse->course_id}",
+            [
+                'tag_id' => $tagCourse->tag_id,
+                'course_id' => $tagCourse->course_id,
+            ]
+        );
+
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('tag_courses', [
+            'tag_id' => $tagCourse->tag_id,
+            'course_id' => $tagCourse->course_id,
+        ]);
+    }
+
+    public function test_get_tags_by_course(): void
+    {
+        $course = Course::factory()->create();
+        $firstTag = Tag::factory()->create();
+        $secondTag = Tag::factory()->create();
+        TagCourse::factory()->create([
+            'course_id' => $course->id,
+            'tag_id' => $firstTag->id,
+        ]);
+        TagCourse::factory()->create([
+            'course_id' => $course->id,
+            'tag_id' => $secondTag->id,
+        ]);
+
+        $response = $this->getJson("/api/admin/courses/{$course->id}/tags");
+
+        $response->assertStatus(200)
+            ->assertJsonCount(2)
+            ->assertJsonFragment(['tag_id' => $firstTag->id])
+            ->assertJsonFragment(['tag_id' => $secondTag->id]);
+    }
+
+    public function test_get_courses_by_tag(): void
+    {
+        $tag = Tag::factory()->create();
+        $firstCourse = Course::factory()->create();
+        $secondCourse = Course::factory()->create();
+        TagCourse::factory()->create([
+            'tag_id' => $tag->id,
+            'course_id' => $firstCourse->id,
+        ]);
+        TagCourse::factory()->create([
+            'tag_id' => $tag->id,
+            'course_id' => $secondCourse->id,
+        ]);
+
+        $response = $this->getJson("/api/admin/tags/{$tag->id}/courses");
+
+        $response->assertStatus(200)
+            ->assertJsonCount(2)
+            ->assertJsonFragment(['course_id' => $firstCourse->id])
+            ->assertJsonFragment(['course_id' => $secondCourse->id]);
+    }
+}

--- a/tests/Feature/Admin/TeachersControllerTest.php
+++ b/tests/Feature/Admin/TeachersControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Teacher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class TeachersControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_lists_teachers(): void
+    {
+        Teacher::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/admin/teachers');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3);
+    }
+
+    public function test_store_creates_teacher_with_avatar(): void
+    {
+        Storage::fake('public');
+
+        $response = $this->post('/api/admin/teachers', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'bio' => 'Experienced mentor',
+            'avatar' => UploadedFile::fake()->image('avatar.jpg'),
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('teachers', [
+            'email' => 'john@example.com',
+        ]);
+    }
+
+    public function test_show_returns_teacher(): void
+    {
+        $teacher = Teacher::factory()->create();
+
+        $response = $this->getJson("/api/admin/teachers/{$teacher->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['id' => $teacher->id]);
+    }
+
+    public function test_update_modifies_teacher(): void
+    {
+        $teacher = Teacher::factory()->create();
+
+        $response = $this->putJson("/api/admin/teachers/{$teacher->id}", [
+            'name' => 'Updated Name',
+            'email' => 'updated@example.com',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('teachers', [
+            'id' => $teacher->id,
+            'name' => 'Updated Name',
+            'email' => 'updated@example.com',
+        ]);
+    }
+
+    public function test_destroy_deletes_teacher(): void
+    {
+        $teacher = Teacher::factory()->create();
+
+        $response = $this->deleteJson("/api/admin/teachers/{$teacher->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('teachers', ['id' => $teacher->id]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,13 +15,32 @@ abstract class TestCase extends BaseTestCase
 
     protected function setUp(): void
     {
+        $this->prepareInMemoryDatabase();
         parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => true,
+        ]);
 
         $this->withoutMiddleware(
             \App\Http\Middleware\VerifyCsrfToken::class
         );
 
         $this->user = $this->login();
+    }
+
+    private function prepareInMemoryDatabase(): void
+    {
+        putenv('DB_CONNECTION=sqlite');
+        putenv('DB_DATABASE=:memory:');
+        $_ENV['DB_CONNECTION'] = 'sqlite';
+        $_ENV['DB_DATABASE'] = ':memory:';
+        $_SERVER['DB_CONNECTION'] = 'sqlite';
+        $_SERVER['DB_DATABASE'] = ':memory:';
     }
 
     public function login()


### PR DESCRIPTION
## Summary
- configure the test environment to use an in-memory sqlite database and register Doctrine enum mappings so migrations run reliably
- add model factories and feature coverage for tags, tag-course relations, teachers, course disable, module index, and refresh endpoints
- limit API resources to implemented actions and persist platform context on tags and users

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e1c681854883269b0bd708f10f1f3e